### PR TITLE
fix docker_tag

### DIFF
--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -28,11 +28,11 @@ jobs:
       - name: Export Docker Tag (Short SHA)
         id: sha
         run: |-
-          echo "::set-output name=git_short_sha::sha-$(git rev-parse --short HEAD)"
+          echo "git_short_sha=sha-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Echo Docker tag
         run: |-
-          echo ${{ steps.sha.outputs.git_short_sha }}
+          echo "${{ env.git_short_sha }}"
 
     outputs:
-      docker_tag: ${{ steps.sha.outputs.git_short_sha }}
+      docker_tag: ${{ env.git_short_sha }}


### PR DESCRIPTION
## Deprecating save-state and set-output commands


https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


Followed this instruction :) 

![image](https://user-images.githubusercontent.com/28991527/195458668-d6426a81-003b-4e26-9e8a-21f63697f312.png)

```bash
jobs:
  docker_tag:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Export Docker Tag (Short SHA)
        id: sha
        run: |-
          echo "git_short_sha=sha-$(git rev-parse --short HEAD)" >> $GITHUB_ENV

      - name: Echo Docker tag
        run: |-
          echo "${{ env.git_short_sha }}"

    outputs:
      docker_tag: ${{ env.git_short_sha }}

```

## Tested in `ruggable-token-faucet ` repo 

![image](https://user-images.githubusercontent.com/28991527/195458547-e97b58c1-5a42-4440-a000-47dd77dc47a5.png)
![image](https://user-images.githubusercontent.com/28991527/195460130-81aa42fc-5bcc-4efb-be46-e2343f4b5456.png)
